### PR TITLE
Add arguments/ Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,43 @@
 # Introduction
 
-Guetzling is a simple script for macOS and Linux written in Bash, to automate (recursively finding files) the compression of jpegs using the Guetzli algorithm.
+Guetzling is a simple script for macOS and Linux written in Bash to automate (recursively finding files) the compression of JPGs and PNGs using the Guetzli algorithm.
 
-## Install
-1. Install [Guetzli](https://github.com/google/guetzli), and copy it to an executable folder (`/usr/bin` for example), if it's not already there.
-2. Copy Guetzling, copy it to `/usr/bin` or something like that.
+By design, Guetzling will overwrite and/or delete your original files.  If you want to keep your originals, make a backup of your folder before using Guetzling.
+
+## Install Guetzli
+1. Install [Guetzli](https://github.com/google/guetzli), via the directions provided at the link.
+2. Copy Guetzling, copy it to `/usr/bin`.
 
 ## Usage
 1. Simply `cd` to the parent directory of your choice, and `guetzling`. ***Voilà!***
+
+## Adjustable Options
+
+By opening the script in a text editor, you can adjust certain variables to change the output of Guetzling.
+
+### JPG
+
+Enable/Disable re-compression of JPG and JPEG files using Guetzling.
+
+	#Recompress JPG Images
+	#Set to false to disable
+	JPG=true
+
+### PNG
+
+Enable/Disable the conversion of PNG to JPG using Guetzling.
+
+	#Convert PNG Images
+	#Set to false to disable
+	#PNGS WILL BE DELETED AFTER CONVERSION
+	PNG=true
+
+### QUALITY
+
+Change Guetzling/Guetzli Quality Level.
+
+	#Set Quality level
+	#Default = 95
+	#Max = 100
+	#Min = 84
+	QUALITY=95

--- a/README.md
+++ b/README.md
@@ -11,33 +11,45 @@ By design, Guetzling will overwrite and/or delete your original files.  If you w
 ## Usage
 1. Simply `cd` to the parent directory of your choice, and `guetzling`. ***Voilà!***
 
-## Adjustable Options
+## Adjustable Parameters
 
-By opening the script in a text editor, you can adjust certain variables to change the output of Guetzling.
+By Default, Guetzling uses the following options:
+ 
+- JPGs are re-compressed and overwritten
+- PNGs are converted to JPG and the originals are deleted
+- Quality Level is for Guetzli is set to 95
 
-### JPG
+You can adjust these options using bash arguments:
 
-Enable/Disable re-compression of JPG and JPEG files using Guetzling.
+1. Quality for JPG re-compression.
+	- Requires a value between 84 and 100 for Guetzli is designed to fail
+	- Default value is the same as Guetzli: 95
+ 
+ 2. Quality for PNG conversion.
+	- Requires a value between 84 and 100 for Guetzli is designed to fail
+	- Default value is the same as Guetzli: 95
+	
+3.  Compress JPGs
+	- Set to "false" and Guetzliing will ignore JPG/JPEG files, compressing only PNGS.
+	
+4. Compress PNGs
+	- Set to "false" and Guetzling will ignore PNG files, compressing only JPGS
+ 
+ 5.  Delete PNG
+ 	- Set to "false" and Guetzling will keep the copy of any original PNGs in your folder
+ 
 
-	#Recompress JPG Images
-	#Set to false to disable
-	JPG=true
+## Example Usage
+ 
+ Replace all files at quality 95:
+ 
+ 	./guetzling
+ 	
+ Convert JPGs at 95, PNGs at 84, and keep your original PNG files:
+ 
+ 	./guetzling 95 84 true true false
+ 	
+ Convert only JPGs at Quality Level 97:
 
-### PNG
-
-Enable/Disable the conversion of PNG to JPG using Guetzling.
-
-	#Convert PNG Images
-	#Set to false to disable
-	#PNGS WILL BE DELETED AFTER CONVERSION
-	PNG=true
-
-### QUALITY
-
-Change Guetzling/Guetzli Quality Level.
-
-	#Set Quality level
-	#Default = 95
-	#Max = 100
-	#Min = 84
-	QUALITY=95
+	./guetzling 97 95 true false
+  	 

--- a/guetzling
+++ b/guetzling
@@ -1,19 +1,28 @@
 #!/bin/bash
 
-#Recompress JPG Images
-#Set to false to disable
-JPG=true
-
-#Convert PNG Images
-#Set to false to disable
-#PNGS WILL BE DELETED AFTER CONVERSION
-PNG=true
+#Set Quality level for JPG recompression
+#Default = 95
+#Max = 100
+#Min = 84
+QUALITY_JPG=${1:-95}
 
 #Set Quality level
 #Default = 95
 #Max = 100
 #Min = 84
-QUALITY=95
+QUALITY_PNG=${2:-95}
+
+#Recompress JPG Images
+#Set to false to disable
+JPG=${3:-true}
+
+#Convert PNG Images
+#Set to false to disable
+#PNGS WILL BE DELETED AFTER CONVERSION UNLESS OTHERWISE SPECIFIED
+PNG=${4:-true}
+
+#Remove original PNGS after conversion to JPG
+PNG_DELETE=${5:-true}
 
 IFS=$'\n';
 FOLDER=$(pwd)
@@ -23,8 +32,8 @@ if [ $JPG = true ];
         for f in $(find "$FOLDER" -name '*.jpg')
         #for f in $1/*.jpg
         do
-	        echo "Guetzling file - $f..."
-	        guetzli --quality "$QUALITY" "$f" "$f"
+	        echo "Guetzling file - $f at level '$QUALITY_JPG'..."
+	        guetzli --quality "$QUALITY_JPG" "$f" "$f"
 	        echo "Done."
         done
 fi
@@ -34,9 +43,9 @@ if [ $JPG = true ];
         for f in $(find "$FOLDER" -name '*.jpeg')
         #for f in $1/*.jpeg
         do
-	        echo "Guetzling file - $f..."
-	        guetzli --quality "$QUALITY" "$f" "$f"
-	        echo "Done."
+            echo "Guetzling file - $f at level '$QUALITY_JPG'..."
+            guetzli --quality "$QUALITY_JPG" "$f" "$f"
+            echo "Done."
         done
 fi
 
@@ -45,9 +54,14 @@ if [ $PNG = true ];
         for f in $(find "$FOLDER" -name '*.png')
         #for f in $1/*.png
         do
-	        echo "Guetzling file - $f..."
-	        guetzli --quality "$QUALITY" "$f" "${f%.png}.jpg"
-    rm "$f"
-	        echo "Done."
+	        echo "Guetzling file - $f at level '$QUALITY_PNG' ..."
+	        guetzli --quality "$QUALITY_PNG" "$f" "${f%.png}.jpg"
+            
+            if [ $PNG_DELETE = true ];
+                then
+                    rm "$f"
+            fi
+	        
+            echo "Done."
         done
 fi

--- a/guetzling
+++ b/guetzling
@@ -1,10 +1,53 @@
 #!/bin/bash
+
+#Recompress JPG Images
+#Set to false to disable
+JPG=true
+
+#Convert PNG Images
+#Set to false to disable
+#PNGS WILL BE DELETED AFTER CONVERSION
+PNG=true
+
+#Set Quality level
+#Default = 95
+#Max = 100
+#Min = 84
+QUALITY=95
+
 IFS=$'\n';
 FOLDER=$(pwd)
-for f in $(find "$FOLDER" -name '*.jpg')
-#for f in $1/*.jpg
-do
-	echo "Guetzling file - $f..."
-	guetzli -quality 95 "$f" "$f"
-	echo "Done."
-done
+
+if [ $JPG = true ];
+    then
+        for f in $(find "$FOLDER" -name '*.jpg')
+        #for f in $1/*.jpg
+        do
+	        echo "Guetzling file - $f..."
+	        guetzli --quality "$QUALITY" "$f" "$f"
+	        echo "Done."
+        done
+fi
+
+if [ $JPG = true ];
+    then
+        for f in $(find "$FOLDER" -name '*.jpeg')
+        #for f in $1/*.jpeg
+        do
+	        echo "Guetzling file - $f..."
+	        guetzli --quality "$QUALITY" "$f" "$f"
+	        echo "Done."
+        done
+fi
+
+if [ $PNG = true ];
+    then
+        for f in $(find "$FOLDER" -name '*.png')
+        #for f in $1/*.png
+        do
+	        echo "Guetzling file - $f..."
+	        guetzli --quality "$QUALITY" "$f" "${f%.png}.jpg"
+    rm "$f"
+	        echo "Done."
+        done
+fi


### PR DESCRIPTION
This should add the arguments you requested but still allow Guetzli to function at default value.

Of course the added features create additional complexity.  There's a much higher chance of user error with this.

Later this week I'll look into how to add flags for better fine-control of the options, and also maybe code in some error messages if the user enters an incorrect parameter- or just plain misses one.

We could also eventually throw in a "verbose" mode which walks the user through the different options and allows then to make selections.

For now though I think this is a good half measure.  Guetzli still requires source compiling to use.  Most of its users are probably familiar with at least basic command line usage.